### PR TITLE
Support multiple topics consumer

### DIFF
--- a/.github/workflows/ci-integration-test.yaml
+++ b/.github/workflows/ci-integration-test.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: run integration tests
         run: |
           export PULSAR_DEPLOYMENT_TYPE=container
-          dotnet test ./tests/DotPulsar.IntegrationTests/DotPulsar.IntegrationTests.csproj --logger "trx;verbosity=detailed"
+          dotnet test ./tests/DotPulsar.IntegrationTests/DotPulsar.IntegrationTests.csproj --logger "console;verbosity=detailed"
 
       - name: package artifacts
         if: failure()

--- a/src/DotPulsar/Abstractions/IConsumer.cs
+++ b/src/DotPulsar/Abstractions/IConsumer.cs
@@ -14,6 +14,7 @@
 
 namespace DotPulsar.Abstractions
 {
+    using Internal;
     using System;
     using System.Collections.Generic;
     using System.Threading;
@@ -27,12 +28,12 @@ namespace DotPulsar.Abstractions
         /// <summary>
         /// Acknowledge the consumption of a single message using the MessageId.
         /// </summary>
-        ValueTask Acknowledge(MessageId messageId, CancellationToken cancellationToken = default);
+        ValueTask Acknowledge(IMessageId messageId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Acknowledge the consumption of all the messages in the topic up to and including the provided MessageId.
         /// </summary>
-        ValueTask AcknowledgeCumulative(MessageId messageId, CancellationToken cancellationToken = default);
+        ValueTask AcknowledgeCumulative(IMessageId messageId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The consumer's service url.
@@ -50,6 +51,37 @@ namespace DotPulsar.Abstractions
         string Topic { get; }
 
         /// <summary>
+        /// The consumer's topic list.
+        /// </summary>
+        ISet<string>? TopicNames { get; }
+
+        /// <summary>
+        /// The consumer's topic pattern.
+        /// </summary>
+        string? TopicsPattern { get; }
+
+        /// <summary>
+        /// The consumer's topic partition number.
+        /// </summary>
+        uint NumberOfPartitions { get; }
+
+        /// <summary>
+        /// Controls whether the consumers automatically update partition data.
+        /// </summary>
+        bool AutoUpdatePartitions { get; }
+
+        /// <summary>
+        /// Set the interval of updating partitions, the default is 1 minute.
+        /// This only works when autoUpdatePartitions is true.
+        /// </summary>
+        TimeSpan AutoUpdatePartitionsInterval { get; }
+
+        /// <summary>
+        /// The subscription mode for TopicsPattern.
+        /// </summary>
+        RegexSubscriptionMode RegexSubscriptionMode { get; }
+
+        /// <summary>
         /// Unsubscribe the consumer.
         /// </summary>
         ValueTask Unsubscribe(CancellationToken cancellationToken = default);
@@ -57,7 +89,7 @@ namespace DotPulsar.Abstractions
         /// <summary>
         /// Redeliver the pending messages that were pushed to this consumer that are not yet acknowledged.
         /// </summary>
-        ValueTask RedeliverUnacknowledgedMessages(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken = default);
+        ValueTask RedeliverUnacknowledgedMessages(IEnumerable<IMessageId> messageIds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Redeliver all pending messages that were pushed to this consumer that are not yet acknowledged.

--- a/src/DotPulsar/Abstractions/IConsumerBuilder.cs
+++ b/src/DotPulsar/Abstractions/IConsumerBuilder.cs
@@ -14,6 +14,10 @@
 
 namespace DotPulsar.Abstractions
 {
+    using Internal;
+    using System;
+    using System.Collections.Generic;
+
     /// <summary>
     /// A consumer building abstraction.
     /// </summary>
@@ -68,5 +72,33 @@ namespace DotPulsar.Abstractions
         /// Create the consumer.
         /// </summary>
         IConsumer<TMessage> Create();
+
+        /// <summary>
+        /// Specify a list of topics that this consumer will subscribe on.
+        /// </summary>
+        /// <param name="topicNames">a list of topic that the consumer will subscribe on</param>
+        IConsumerBuilder<TMessage> Topics(IEnumerable<string> topicNames);
+
+        /// <summary>
+        /// Specify a pattern for topics that this consumer will subscribe on.
+        /// </summary>
+        /// <param name="topicsPattern">a regular expression to select a list of topics to subscribe to</param>
+        IConsumerBuilder<TMessage> TopicsPattern(string topicsPattern);
+
+        /// <summary>
+        /// The subscription mode for TopicsPattern.
+        /// </summary>
+        IConsumerBuilder<TMessage> RegexSubscriptionMode(RegexSubscriptionMode mode);
+
+        /// <summary>
+        /// Controls whether the consumers automatically update partition data, the default is false.
+        /// </summary>
+        IConsumerBuilder<TMessage> AutoUpdatePartitions(bool enabled);
+
+        /// <summary>
+        /// Set the interval of updating partitions, the default is 1 minute.
+        /// This only works when autoUpdatePartitions is true.
+        /// </summary>
+        IConsumerBuilder<TMessage> AutoUpdatePartitionsInterval(TimeSpan timeSpan);
     }
 }

--- a/src/DotPulsar/Abstractions/IGetLastMessageId.cs
+++ b/src/DotPulsar/Abstractions/IGetLastMessageId.cs
@@ -25,6 +25,6 @@ namespace DotPulsar.Abstractions
         /// <summary>
         /// Get the MessageId of the last message on the topic.
         /// </summary>
-        ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken = default);
+        ValueTask<IMessageId> GetLastMessageId(CancellationToken cancellationToken = default);
     }
 }

--- a/src/DotPulsar/Abstractions/IMessage.cs
+++ b/src/DotPulsar/Abstractions/IMessage.cs
@@ -122,5 +122,10 @@ namespace DotPulsar.Abstractions
         /// The properties of the message.
         /// </summary>
         public IReadOnlyDictionary<string, string> Properties { get; }
+
+        /// <summary>
+        /// The topic of the message.
+        /// </summary>
+        public string Topic { get; }
     }
 }

--- a/src/DotPulsar/Abstractions/IMessageId.cs
+++ b/src/DotPulsar/Abstractions/IMessageId.cs
@@ -1,0 +1,14 @@
+namespace DotPulsar.Abstractions
+{
+    using Internal.PulsarApi;
+    using System;
+
+    /// <summary>
+    /// The interface for support multiple or single message id.
+    /// </summary>
+    public interface IMessageId : IComparable
+    {
+        public string Topic { get; }
+        public MessageIdData ToMessageIdData();
+    }
+}

--- a/src/DotPulsar/ConsumerOptions.cs
+++ b/src/DotPulsar/ConsumerOptions.cs
@@ -14,7 +14,10 @@
 
 namespace DotPulsar
 {
-    using DotPulsar.Abstractions;
+    using Abstractions;
+    using Internal;
+    using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// The consumer building options.
@@ -47,9 +50,24 @@ namespace DotPulsar
         public static readonly SubscriptionType DefaultSubscriptionType = SubscriptionType.Exclusive;
 
         /// <summary>
+        /// The default RegexSubscriptionMode value.
+        /// </summary>
+        public static readonly RegexSubscriptionMode DefaultRegexSubscriptionMode = RegexSubscriptionMode.AllTopics;
+
+        /// <summary>
+        /// The default AutoUpdatePartitions value.
+        /// </summary>
+        public static readonly bool DefaultAutoUpdatePartitions = false;
+
+        /// <summary>
+        /// The default AutoUpdatePartitionsInterval value.
+        /// </summary>
+        public static readonly TimeSpan DefaultAutoUpdatePartitionsInterval = TimeSpan.FromMinutes(1);
+
+        /// <summary>
         /// Initializes a new instance using the specified subscription name and topic.
         /// </summary>
-        public ConsumerOptions(string subscriptionName, string topic, ISchema<TMessage> schema)
+        public ConsumerOptions(string subscriptionName, ISet<string> topicNames, ISchema<TMessage> schema)
         {
             InitialPosition = DefaultInitialPosition;
             PriorityLevel = DefaultPriorityLevel;
@@ -57,8 +75,10 @@ namespace DotPulsar
             ReadCompacted = DefaultReadCompacted;
             SubscriptionType = DefaultSubscriptionType;
             SubscriptionName = subscriptionName;
-            Topic = topic;
+            TopicNames = topicNames;
             Schema = schema;
+            AutoUpdatePartitions = DefaultAutoUpdatePartitions;
+            AutoUpdatePartitionsInterval = DefaultAutoUpdatePartitionsInterval;
         }
 
         /// <summary>
@@ -107,8 +127,29 @@ namespace DotPulsar
         public SubscriptionType SubscriptionType { get; set; }
 
         /// <summary>
-        /// Set the topic for this consumer. This is required.
+        /// Set the topic names for this consumer.
         /// </summary>
-        public string Topic { get; set; }
-    }
+        public ISet<string> TopicNames { get; set; }
+
+        /// <summary>
+        /// Set the topic pattern for this consumer.
+        /// </summary>
+        public string? TopicsPattern { get; set; }
+
+        /// <summary>
+        /// The subscription mode for TopicsPattern.
+        /// </summary>
+        public RegexSubscriptionMode RegexSubscriptionMode { get; set; }
+
+        /// <summary>
+        /// Controls whether the consumers automatically update partition data.
+        /// </summary>
+        public bool AutoUpdatePartitions { get; set; }
+
+        /// <summary>
+        /// Set the interval of updating partitions, the default is 1 minute.
+        /// This only works when autoUpdatePartitions is true.
+        /// </summary>
+        public TimeSpan AutoUpdatePartitionsInterval { get; set; }
+    };
 }

--- a/src/DotPulsar/DotPulsar.csproj
+++ b/src/DotPulsar/DotPulsar.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="HashDepot" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.7" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.0"/>
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
   </ItemGroup>

--- a/src/DotPulsar/Internal/Abstractions/IConnection.cs
+++ b/src/DotPulsar/Internal/Abstractions/IConnection.cs
@@ -42,5 +42,6 @@ namespace DotPulsar.Internal.Abstractions
         Task<BaseCommand> Send(SendPackage command, CancellationToken cancellationToken);
         Task<BaseCommand> Send(CommandGetOrCreateSchema command, CancellationToken cancellationToken);
         Task<BaseCommand> Send(CommandPartitionedTopicMetadata command, CancellationToken cancellationToken);
+        Task<BaseCommand> Send(CommandGetTopicsOfNamespace command, CancellationToken cancellationToken);
     }
 }

--- a/src/DotPulsar/Internal/Abstractions/IConsumerChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IConsumerChannel.cs
@@ -26,8 +26,8 @@ namespace DotPulsar.Internal.Abstractions
         Task Send(CommandRedeliverUnacknowledgedMessages command, CancellationToken cancellationToken);
         Task Send(CommandUnsubscribe command, CancellationToken cancellationToken);
         Task Send(CommandSeek command, CancellationToken cancellationToken);
-        Task<MessageId> Send(CommandGetLastMessageId command, CancellationToken cancellationToken);
-        ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken);
+        Task<MessageId> Send(string topic, CommandGetLastMessageId command, CancellationToken cancellationToken);
+        ValueTask<IMessage<TMessage>> Receive(string topic, CancellationToken cancellationToken);
         ValueTask ClosedByClient(CancellationToken cancellationToken);
     }
 }

--- a/src/DotPulsar/Internal/Abstractions/IMessageFactory.cs
+++ b/src/DotPulsar/Internal/Abstractions/IMessageFactory.cs
@@ -15,11 +15,13 @@
 namespace DotPulsar.Internal.Abstractions
 {
     using DotPulsar.Abstractions;
-    using DotPulsar.Internal.PulsarApi;
+    using PulsarApi;
     using System.Buffers;
 
     public interface IMessageFactory<TValue>
     {
-        IMessage<TValue> Create(MessageId messageId, uint redeliveryCount, ReadOnlySequence<byte> data, MessageMetadata metadata, SingleMessageMetadata? singleMetadata = null);
+        IMessage<TValue> Create(string topic, MessageId messageId, uint redeliveryCount, ReadOnlySequence<byte> data,
+            MessageMetadata metadata, SingleMessageMetadata? singleMetadata
+                = null);
     }
 }

--- a/src/DotPulsar/Internal/AsyncQueue.cs
+++ b/src/DotPulsar/Internal/AsyncQueue.cs
@@ -42,6 +42,7 @@ namespace DotPulsar.Internal
                 ThrowIfDisposed();
 
                 var node = _pendingDequeues.First;
+
                 if (node is not null)
                 {
                     node.Value.SetResult(item);
@@ -51,6 +52,11 @@ namespace DotPulsar.Internal
                 else
                     _queue.Enqueue(item);
             }
+        }
+
+        public int Count
+        {
+            get { return _queue.Count; }
         }
 
         public ValueTask<T> Dequeue(CancellationToken cancellationToken = default)

--- a/src/DotPulsar/Internal/BatchHandler.cs
+++ b/src/DotPulsar/Internal/BatchHandler.cs
@@ -14,8 +14,8 @@
 
 namespace DotPulsar.Internal
 {
+    using Abstractions;
     using DotPulsar.Abstractions;
-    using DotPulsar.Internal.Abstractions;
     using Extensions;
     using PulsarApi;
     using System.Buffers;
@@ -29,14 +29,16 @@ namespace DotPulsar.Internal
         private readonly IMessageFactory<TMessage> _messageFactory;
         private readonly Queue<IMessage<TMessage>> _messages;
         private readonly LinkedList<Batch> _batches;
+        private readonly string _topic;
 
-        public BatchHandler(bool trackBatches, IMessageFactory<TMessage> messageFactory)
+        public BatchHandler(string topic, bool trackBatches, IMessageFactory<TMessage> messageFactory)
         {
             _lock = new object();
             _trackBatches = trackBatches;
             _messageFactory = messageFactory;
             _messages = new Queue<IMessage<TMessage>>();
             _batches = new LinkedList<Batch>();
+            _topic = topic;
         }
 
         public IMessage<TMessage> Add(MessageIdData messageId, uint redeliveryCount, MessageMetadata metadata, ReadOnlySequence<byte> data)
@@ -49,10 +51,12 @@ namespace DotPulsar.Internal
             {
                 var singleMetadataSize = data.ReadUInt32(index, true);
                 index += 4;
+
                 var singleMetadata = Serializer.Deserialize<SingleMessageMetadata>(data.Slice(index, singleMetadataSize));
                 index += singleMetadataSize;
-                var singleMessageId = new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition, i);
-                var message = _messageFactory.Create(singleMessageId, redeliveryCount, data.Slice(index, singleMetadata.PayloadSize), metadata, singleMetadata);
+                var singleMessageId = new MessageId(messageId.LedgerId, messageId.EntryId, messageId.Partition, i, _topic);
+
+                var message = _messageFactory.Create(_topic, singleMessageId, redeliveryCount, data.Slice(index, singleMetadata.PayloadSize), metadata, singleMetadata);
                 messages.Add(message);
                 index += (uint) singleMetadata.PayloadSize;
             }

--- a/src/DotPulsar/Internal/Consumer.cs
+++ b/src/DotPulsar/Internal/Consumer.cs
@@ -20,11 +20,13 @@ namespace DotPulsar.Internal
     using DotPulsar.Exceptions;
     using DotPulsar.Extensions;
     using Extensions;
+    using Nito.AsyncEx;
     using PulsarApi;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -37,9 +39,11 @@ namespace DotPulsar.Internal
         private readonly StateManager<ConsumerState> _state;
         private readonly IConnectionPool _connectionPool;
         private readonly CancellationTokenSource _cts;
-        private readonly ConcurrentDictionary<int, IConsumer<TMessage>> _consumers;
+        private readonly ConcurrentDictionary<string, IConsumer<TMessage>> _consumers;
+        private readonly AsyncReaderWriterLock _lock;
+
+        private List<Task<ConsumerStateChanged>> _monitoringTasks;
         private ConcurrentQueue<IMessage<TMessage>> _messagesQueue;
-        private bool _isPartitionedTopic = false;
         private int _consumersCount;
         private int _isDisposed;
         private Exception? _throw;
@@ -47,6 +51,12 @@ namespace DotPulsar.Internal
         public Uri ServiceUrl { get; }
         public string SubscriptionName { get; }
         public string Topic { get; }
+        public ISet<string>? TopicNames { get; }
+        public string? TopicsPattern { get; }
+        public RegexSubscriptionMode RegexSubscriptionMode { get; }
+        public uint NumberOfPartitions { get; }
+        public bool AutoUpdatePartitions { get; }
+        public TimeSpan AutoUpdatePartitionsInterval { get; }
 
         public Consumer(
             Uri serviceUrl,
@@ -55,10 +65,16 @@ namespace DotPulsar.Internal
             IHandleException exceptionHandler,
             IConnectionPool connectionPool)
         {
-            _state = new StateManager<ConsumerState>(ConsumerState.Disconnected, ConsumerState.Closed, ConsumerState.ReachedEndOfTopic, ConsumerState.Faulted);
+            _state = new StateManager<ConsumerState>(ConsumerState.Disconnected, ConsumerState.Closed,
+                ConsumerState.ReachedEndOfTopic, ConsumerState.Faulted);
             ServiceUrl = serviceUrl;
-            Topic = options.Topic;
+            Topic = "ROOT_CONSUMER";
+            TopicNames = options.TopicNames;
+            TopicsPattern = options.TopicsPattern;
+            RegexSubscriptionMode = options.RegexSubscriptionMode;
             SubscriptionName = options.SubscriptionName;
+            AutoUpdatePartitions = options.AutoUpdatePartitions;
+            AutoUpdatePartitionsInterval = options.AutoUpdatePartitionsInterval;
             _options = options;
             _exceptionHandler = exceptionHandler;
             _processManager = processManager;
@@ -66,8 +82,25 @@ namespace DotPulsar.Internal
             _cts = new CancellationTokenSource();
             _executor = new Executor(Guid.Empty, this, _exceptionHandler);
             _isDisposed = 0;
-            _consumers = new ConcurrentDictionary<int, IConsumer<TMessage>>();
+            _consumers = new ConcurrentDictionary<string, IConsumer<TMessage>>();
             _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>();
+            _lock = new AsyncReaderWriterLock();
+            _monitoringTasks = new List<Task<ConsumerStateChanged>>();
+
+            if (!string.IsNullOrEmpty(TopicsPattern))
+            {
+                if (TopicNames != null && TopicNames.Count != 0)
+                {
+                    throw new ArgumentException("Topic names list must be null when use topicsPattern");
+                }
+            }
+            else
+            {
+                if (TopicNames == null || TopicNames.Count == 0)
+                {
+                    throw new ArgumentException("Topic names list cannot be null");
+                }
+            }
 
             _ = Setup();
         }
@@ -78,7 +111,18 @@ namespace DotPulsar.Internal
 
             try
             {
-                await _executor.Execute(Monitor, _cts.Token).ConfigureAwait(false);
+                List<string> topics;
+
+                if (!string.IsNullOrEmpty(TopicsPattern))
+                {
+                    topics = await GetPatternTopic(TopicsPattern!);
+                }
+                else
+                {
+                    topics = TopicNames!.ToList();
+                }
+
+                await _executor.Execute(() => Monitor(topics), _cts.Token).ConfigureAwait(false);
             }
             catch (Exception exception)
             {
@@ -107,48 +151,120 @@ namespace DotPulsar.Internal
             };
             var messagePrefetchCount = _options.MessagePrefetchCount;
             var messageFactory = new MessageFactory<TMessage>(_options.Schema);
-            var batchHandler = new BatchHandler<TMessage>(true, messageFactory);
+            var batchHandler = new BatchHandler<TMessage>(topic, true, messageFactory);
             var decompressorFactories = CompressionFactories.DecompressorFactories();
 
-            var factory = new ConsumerChannelFactory<TMessage>(correlationId, _processManager, _connectionPool, subscribe, messagePrefetchCount, batchHandler, messageFactory,
+            var factory = new ConsumerChannelFactory<TMessage>(correlationId, _processManager, _connectionPool,
+                subscribe, messagePrefetchCount, batchHandler, messageFactory,
                 decompressorFactories);
-            var stateManager = new StateManager<ConsumerState>(ConsumerState.Disconnected, ConsumerState.Closed, ConsumerState.ReachedEndOfTopic, ConsumerState.Faulted);
+
+            var stateManager = new StateManager<ConsumerState>(ConsumerState.Disconnected, ConsumerState.Closed,
+                ConsumerState.ReachedEndOfTopic, ConsumerState.Faulted);
             var initialChannel = new NotReadyChannel<TMessage>();
             var executor = new Executor(correlationId, _processManager, _exceptionHandler);
-            var consumer = new SubConsumer<TMessage>(correlationId, ServiceUrl, _options.SubscriptionName, topic, _processManager, initialChannel, executor, stateManager, factory);
-            var process = new ConsumerProcess(correlationId, stateManager, consumer, _options.SubscriptionType == SubscriptionType.Failover);
+
+            var consumer = new SubConsumer<TMessage>(correlationId, ServiceUrl, _options.SubscriptionName, topic,
+                _processManager, initialChannel, executor, stateManager, factory);
+
+            var process = new ConsumerProcess(correlationId, stateManager, consumer,
+                _options.SubscriptionType == SubscriptionType.Failover);
             _processManager.Add(process);
             process.Start();
             return consumer;
         }
 
-        private async Task Monitor()
+        private async Task TopicChangesMonitor(IReadOnlyCollection<string> topics)
         {
-            var numberOfPartitions = await GetNumberOfPartitions(Topic, _cts.Token).ConfigureAwait(false);
-            _isPartitionedTopic = numberOfPartitions != 0;
-            var monitoringTasks = new Task<ConsumerStateChanged>[_isPartitionedTopic ? numberOfPartitions : 1];
+            var delay = TimeSpan.FromMilliseconds(AutoUpdatePartitionsInterval.TotalMilliseconds);
 
-            var topic = Topic;
-
-            for (var partition = 0; partition < monitoringTasks.Length; ++partition)
+            while (!_cts.IsCancellationRequested)
             {
-                if (_isPartitionedTopic)
-                    topic = $"{Topic}-partition-{partition}";
+                await Task.Delay(delay);
 
-                var consumer = CreateSubConsumer(topic);
-                _ = _consumers.TryAdd(partition, consumer);
-                monitoringTasks[partition] = consumer.StateChangedFrom(ConsumerState.Disconnected, _cts.Token).AsTask();
+                using (_lock.WriterLock())
+                {
+                    try
+                    {
+                        var oldTopics = _consumers.Keys;
+                        var newTopics = await GenerateSubscriptionTopics(topics);
+
+                        // Not changed
+                        if (newTopics.OrderBy(n => n).SequenceEqual(oldTopics.OrderBy(n => n)))
+                        {
+                            continue;
+                        }
+
+                        List<IMessage<TMessage>> newMessagesQueue = _messagesQueue.ToList();
+                        List<Task<ConsumerStateChanged>> newMonitoringTasks = _monitoringTasks.ToList();
+
+                        var removeTopics = oldTopics.Where(x => !newTopics.Contains(x)).ToList();
+
+                        removeTopics.ForEach(n =>
+                        {
+                            _consumers.TryRemove(n, out var consumer);
+                            consumer?.DisposeAsync();
+
+                            newMessagesQueue = newMessagesQueue.Where(m => !m.Topic.Equals(n)).ToList();
+                            newMonitoringTasks = newMonitoringTasks.Where(m => !m.Result.Consumer.Topic.Equals(n)).ToList();
+                        });
+
+                        var addTopics = newTopics.Where(x => !oldTopics.Contains(x)).ToList();
+
+                        addTopics.ForEach(topic =>
+                        {
+                            var consumer = CreateSubConsumer(topic);
+                            _consumers.TryAdd(topic, consumer);
+                            newMonitoringTasks!.Add(consumer.StateChangedFrom(ConsumerState.Disconnected, _cts.Token).AsTask());
+                        });
+
+                        _monitoringTasks = newMonitoringTasks;
+                        _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>(newMessagesQueue);
+                        Interlocked.Exchange(ref _consumersCount, _monitoringTasks.Count);
+                    }
+                    catch (Exception)
+                    {
+                        // ignored
+                    }
+                }
+            }
+        }
+
+        private async Task Monitor(IEnumerable<string> topics)
+        {
+            var topicList = topics.ToList();
+            var subscriptionTopics = await GenerateSubscriptionTopics(topicList);
+
+            using (_lock.ReaderLock())
+            {
+                foreach (var topic in subscriptionTopics)
+                {
+                    var consumer = CreateSubConsumer(topic);
+                    _ = _consumers.TryAdd(topic, consumer);
+                    _monitoringTasks.Add(consumer.StateChangedFrom(ConsumerState.Disconnected, _cts.Token).AsTask());
+                }
+
+                Interlocked.Exchange(ref _consumersCount, _monitoringTasks.Count);
             }
 
-            Interlocked.Exchange(ref _consumersCount, monitoringTasks.Length);
+            if (AutoUpdatePartitions)
+            {
+                _ = _executor.Execute(() => TopicChangesMonitor(topicList)).ConfigureAwait(false);
+            }
 
             var activeConsumers = 0;
 
             while (true)
             {
+                List<Task<ConsumerStateChanged>> monitoringTasks;
+
+                using (_lock.ReaderLock())
+                {
+                    monitoringTasks = _monitoringTasks.ToList();
+                }
+
                 await Task.WhenAny(monitoringTasks).ConfigureAwait(false);
 
-                for (var i = 0; i < monitoringTasks.Length; ++i)
+                for (var i = 0; i < monitoringTasks.Count; ++i)
                 {
                     var task = monitoringTasks[i];
 
@@ -176,36 +292,122 @@ namespace DotPulsar.Internal
                             return;
                     }
 
-                    monitoringTasks[i] = task.Result.Consumer.StateChangedFrom(state, _cts.Token).AsTask();
+                    using (_lock.WriterLock())
+                    {
+                        var index = i;
+
+                        if (monitoringTasks.Count != _monitoringTasks.Count)
+                        {
+                            index = _monitoringTasks.FindIndex(n
+                                => n.Result.Consumer.Topic.Equals(task.Result.Consumer.Topic));
+                        }
+
+                        if (index != -1)
+                        {
+                            _monitoringTasks[i] = task.Result.Consumer.StateChangedFrom(state, _cts.Token).AsTask();
+                        }
+                    }
                 }
 
                 if (activeConsumers == 0)
                     _state.SetState(ConsumerState.Disconnected);
-                else if (activeConsumers == monitoringTasks.Length)
+                else if (activeConsumers == monitoringTasks.Count)
                     _state.SetState(ConsumerState.Active);
                 else
                     _state.SetState(ConsumerState.PartiallyActive);
             }
         }
 
+        private static GetTopicsUnderNamespaceMode ConvertRegexSubscriptionMode(
+            RegexSubscriptionMode regexSubscriptionMode)
+        {
+            return regexSubscriptionMode switch
+            {
+                RegexSubscriptionMode.PersistentOnly => GetTopicsUnderNamespaceMode.PERSISTENT,
+                RegexSubscriptionMode.NonPersistentOnly => GetTopicsUnderNamespaceMode.NON_PERSISTENT,
+                RegexSubscriptionMode.AllTopics => GetTopicsUnderNamespaceMode.ALL,
+                _ => throw new ArgumentOutOfRangeException(nameof(regexSubscriptionMode), regexSubscriptionMode, null)
+            };
+        }
+
+        private async Task<List<string>> GetPatternTopic(string pattern)
+        {
+            var destination = new TopicName(pattern);
+            var mode = ConvertRegexSubscriptionMode(RegexSubscriptionMode);
+            NamespaceName namespaceName = destination.GetNamespaceName();
+
+            var pbMode = mode switch
+            {
+                GetTopicsUnderNamespaceMode.PERSISTENT => CommandGetTopicsOfNamespace.ModeType.Persistent,
+                GetTopicsUnderNamespaceMode.NON_PERSISTENT => CommandGetTopicsOfNamespace.ModeType.NonPersistent,
+                GetTopicsUnderNamespaceMode.ALL => CommandGetTopicsOfNamespace.ModeType.All,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            var req = new CommandGetTopicsOfNamespace { Namespace = namespaceName.ToString(), Mode = pbMode };
+            var connection = await _connectionPool.GetConnection(ServiceUrl, _cts.Token).ConfigureAwait(false);
+            var response = await connection.Send(req, _cts.Token).ConfigureAwait(false);
+            response.Expect(BaseCommand.Type.GetTopicsOfNamespaceResponse);
+
+            var topics = response.GetTopicsOfNamespaceResponse.Topics;
+
+            Regex topicPatternRegex = TopicsPattern!.Contains("://")
+                ? new Regex(TopicsPattern.Split(new[] { "://" }, StringSplitOptions.None)[1])
+                : new Regex(TopicsPattern);
+
+            var filteredTopics = topics.Select(n => new TopicName(n))
+                .Select(n => n.ToString())
+                .Where(n => topicPatternRegex.IsMatch(n.Split(new[] { "://" }, StringSplitOptions.None)[1]))
+                .ToList();
+
+            return filteredTopics;
+        }
+
         private async Task<uint> GetNumberOfPartitions(string topic, CancellationToken cancellationToken)
         {
-            var connection = await _connectionPool.FindConnectionForTopic(topic, cancellationToken).ConfigureAwait(false);
+            var connection = await _connectionPool.FindConnectionForTopic(topic, cancellationToken)
+                .ConfigureAwait(false);
             var commandPartitionedMetadata = new CommandPartitionedTopicMetadata { Topic = topic };
             var response = await connection.Send(commandPartitionedMetadata, cancellationToken).ConfigureAwait(false);
 
             response.Expect(BaseCommand.Type.PartitionedMetadataResponse);
 
-            if (response.PartitionMetadataResponse.Response == CommandPartitionedTopicMetadataResponse.LookupType.Failed)
+            if (response.PartitionMetadataResponse.Response ==
+                CommandPartitionedTopicMetadataResponse.LookupType.Failed)
                 response.PartitionMetadataResponse.Throw();
 
             return response.PartitionMetadataResponse.Partitions;
         }
 
+        private async Task<List<string>> GenerateSubscriptionTopics(IEnumerable<string> originalTopics)
+        {
+            var topicNumberOfPartitionsDictionary = new Dictionary<string, uint>();
+
+            foreach (var topic in originalTopics)
+            {
+                var numberOfPartitions = await GetNumberOfPartitions(topic, _cts.Token).ConfigureAwait(false);
+                topicNumberOfPartitionsDictionary.Add(topic, numberOfPartitions);
+            }
+
+            return topicNumberOfPartitionsDictionary
+                .Where(n => n.Value == 0)
+                .Select(n => n.Key)
+                .Concat(
+                    topicNumberOfPartitionsDictionary
+                        .Where(n => n.Value != 0)
+                        .Select(n =>
+                        {
+                            return Enumerable.Range(0, Convert.ToInt32(n.Value)).Select(m => $"{n.Key}-partition-{m}");
+                        })
+                        .SelectMany(n => n)
+                ).ToList();
+        }
+
         public async ValueTask<ConsumerState> OnStateChangeTo(ConsumerState state, CancellationToken cancellationToken)
             => await _state.StateChangedTo(state, cancellationToken).ConfigureAwait(false);
 
-        public async ValueTask<ConsumerState> OnStateChangeFrom(ConsumerState state, CancellationToken cancellationToken)
+        public async ValueTask<ConsumerState> OnStateChangeFrom(ConsumerState state,
+            CancellationToken cancellationToken)
             => await _state.StateChangedFrom(state, cancellationToken).ConfigureAwait(false);
 
         public bool IsFinalState()
@@ -224,9 +426,12 @@ namespace DotPulsar.Internal
 
             _state.SetState(ConsumerState.Closed);
 
-            foreach (var consumer in _consumers.Values)
+            using (_lock.ReaderLock())
             {
-                await consumer.DisposeAsync().ConfigureAwait(false);
+                foreach (var consumer in _consumers.Values)
+                {
+                    await consumer.DisposeAsync().ConfigureAwait(false);
+                }
             }
         }
 
@@ -234,56 +439,89 @@ namespace DotPulsar.Internal
         {
             ThrowIfDisposed();
 
-            return await _executor.Execute(() => ReceiveMessage(cancellationToken), cancellationToken).ConfigureAwait(false);
+            return await _executor.Execute(() => ReceiveMessage(cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
 
         private async ValueTask<IMessage<TMessage>> ReceiveMessage(CancellationToken cancellationToken)
         {
             ThrowIfNotActive();
 
-            if (_messagesQueue.TryDequeue(out IMessage<TMessage> message))
-                return message;
+            using (_lock.ReaderLock())
+            {
+                if (_messagesQueue.TryDequeue(out var message))
+                {
+                    return message;
+                }
 
-            var cts = new CancellationTokenSource();
-            Task<IMessage<TMessage>>[] receiveTasks = _consumers.Values.Select(consumer => consumer.Receive(cts.Token).AsTask()).ToArray();
-            await Task.WhenAny(receiveTasks).ConfigureAwait(false);
+                var cts = new CancellationTokenSource();
 
-            receiveTasks.Where(t => t.IsCompleted).ToList().ForEach(t =>
-                _messagesQueue.Enqueue(t.Result)
-            );
+                while (!cts.IsCancellationRequested)
+                {
+                    var done = false;
 
-            cts.Cancel();
-            cts.Dispose();
+                    Task<IMessage<TMessage>>[] receiveTasks = _consumers.Values.Select(consumer => consumer.Receive(cts.Token).AsTask()).ToArray();
+                    await Task.WhenAny(receiveTasks).ConfigureAwait(false);
 
-            _messagesQueue.TryDequeue(out message);
-            return message;
+                    receiveTasks.Where(t => t.IsCompleted).ToList().ForEach(t =>
+                        {
+                            if (t.Result == null)
+                            {
+                                return;
+                            }
+
+                            done = true;
+                            _messagesQueue.Enqueue(t.Result);
+                        }
+                    );
+
+                    if (done)
+                    {
+                        break;
+                    }
+                }
+
+                cts.Cancel();
+                cts.Dispose();
+
+                _messagesQueue.TryDequeue(out var result);
+                return result;
+            }
         }
 
-        public async ValueTask Acknowledge(MessageId messageId, CancellationToken cancellationToken)
+        public async ValueTask Acknowledge(IMessageId messageId, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             await _executor.Execute(() =>
                 {
                     ThrowIfNotActive();
-                    return _consumers[_isPartitionedTopic ? messageId.Partition : 0].Acknowledge(messageId, cancellationToken);
+
+                    using (_lock.ReaderLock())
+                    {
+                        return _consumers[messageId.Topic].Acknowledge(messageId, cancellationToken);
+                    }
                 }, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        public async ValueTask AcknowledgeCumulative(MessageId messageId, CancellationToken cancellationToken)
+        public async ValueTask AcknowledgeCumulative(IMessageId messageId, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             await _executor.Execute(() =>
                 {
                     ThrowIfNotActive();
-                    return _consumers[_isPartitionedTopic ? messageId.Partition : 0].AcknowledgeCumulative(messageId, cancellationToken);
+
+                    using (_lock.ReaderLock())
+                    {
+                        return _consumers[messageId.Topic].AcknowledgeCumulative(messageId, cancellationToken);
+                    }
                 }, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        public async ValueTask RedeliverUnacknowledgedMessages(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken = default)
+        public async ValueTask RedeliverUnacknowledgedMessages(IEnumerable<IMessageId> messageIds, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
 
@@ -291,10 +529,13 @@ namespace DotPulsar.Internal
             {
                 ThrowIfNotActive();
 
-                var tasks = messageIds.ToList().Select(messageId =>
-                    _consumers[_isPartitionedTopic ? messageId.Partition : 0].RedeliverUnacknowledgedMessages(cancellationToken).AsTask()
-                );
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                using (_lock.ReaderLock())
+                {
+                    var tasks = messageIds.Select(n =>
+                        _consumers[n.Topic].RedeliverUnacknowledgedMessages(cancellationToken).AsTask()
+                    );
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
 
@@ -306,10 +547,13 @@ namespace DotPulsar.Internal
             {
                 ThrowIfNotActive();
 
-                var tasks = _consumers.Values.ToList().Select(consumer =>
-                    consumer.RedeliverUnacknowledgedMessages(cancellationToken).AsTask()
-                );
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                using (_lock.ReaderLock())
+                {
+                    var tasks = _consumers.Values.Select(consumer =>
+                        consumer.RedeliverUnacknowledgedMessages(cancellationToken).AsTask()
+                    );
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
 
@@ -321,10 +565,13 @@ namespace DotPulsar.Internal
             {
                 ThrowIfNotActive();
 
-                var tasks = _consumers.Values.ToList().Select(consumer =>
-                    consumer.Unsubscribe(cancellationToken).AsTask()
-                );
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                using (_lock.ReaderLock())
+                {
+                    var tasks = _consumers.Values.Select(consumer =>
+                        consumer.Unsubscribe(cancellationToken).AsTask()
+                    );
+                    await Task.WhenAll(tasks).ConfigureAwait(false);
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
 
@@ -342,16 +589,20 @@ namespace DotPulsar.Internal
             {
                 ThrowIfNotActive();
 
-                if (_isPartitionedTopic && messageId.Equals(null) || IsIllegalMultiTopicsMessageId(messageId))
+                using (_lock.ReaderLock())
                 {
-                    throw new ArgumentException("Illegal messageId, messageId can only be earliest/latest.");
-                }
+                    if (_consumers.Values.All(n => messageId.Equals(null) && n.NumberOfPartitions != 0) ||
+                        IsIllegalMultiTopicsMessageId(messageId))
+                    {
+                        throw new ArgumentException("Illegal messageId can only be earliest/latest.");
+                    }
 
-                var tasks = _consumers.Values.ToList().Select(consumer =>
-                    consumer.Seek(messageId, cancellationToken).AsTask()
-                );
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
-                _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>();
+                    var tasks = _consumers.Values.Select(consumer =>
+                        consumer.Seek(messageId, cancellationToken).AsTask()
+                    );
+                    await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                    _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>();
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
 
@@ -363,29 +614,50 @@ namespace DotPulsar.Internal
             {
                 ThrowIfNotActive();
 
-                var tasks = _consumers.Values.ToList().Select(consumer =>
-                    consumer.Seek(publishTime, cancellationToken).AsTask()
-                );
-                await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
-                _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>();
+                using (_lock.ReaderLock())
+                {
+                    var tasks = _consumers.Values.Select(consumer =>
+                        consumer.Seek(publishTime, cancellationToken).AsTask()
+                    );
+                    await Task.WhenAll(tasks.ToArray()).ConfigureAwait(false);
+                    _messagesQueue = new ConcurrentQueue<IMessage<TMessage>>();
+                }
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        public async ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken)
+        public async ValueTask<IMessageId> GetLastMessageId(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             var getLastMessageId = new CommandGetLastMessageId();
-            return await _executor.Execute(() => GetLastMessageId(getLastMessageId, cancellationToken), cancellationToken).ConfigureAwait(false);
+
+            return await _executor
+                .Execute(() => GetLastMessageId(getLastMessageId, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        private async ValueTask<MessageId> GetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
+        private async ValueTask<IMessageId> GetLastMessageId(CommandGetLastMessageId command,
+            CancellationToken cancellationToken)
         {
             ThrowIfNotActive();
 
-            if (_isPartitionedTopic)
-                throw new NotImplementedException();
-            return await _consumers[0].GetLastMessageId(cancellationToken).ConfigureAwait(false);
+            using (_lock.ReaderLock())
+            {
+                if (_consumers.Count == 1)
+                {
+                    return await _consumers.Values.First().GetLastMessageId(cancellationToken).ConfigureAwait(false);
+                }
+
+                var messageIdMap = new Dictionary<string, IMessageId>();
+
+                foreach (var consumer in _consumers)
+                {
+                    var m = await consumer.Value.GetLastMessageId(cancellationToken).ConfigureAwait(false);
+                    messageIdMap.Add(consumer.Key, m);
+                }
+
+                return new MultiMessageId(messageIdMap);
+            }
         }
 
         private void ThrowIfDisposed()

--- a/src/DotPulsar/Internal/Extensions/CommandExtensions.cs
+++ b/src/DotPulsar/Internal/Extensions/CommandExtensions.cs
@@ -64,8 +64,10 @@ namespace DotPulsar.Internal.Extensions
                 ServerError.MetadataError => new MetadataException(message),
                 ServerError.NotAllowedError => new NotAllowedException(message),
                 ServerError.PersistenceError => new PersistenceException(message),
-                ServerError.ProducerBlockedQuotaExceededError => new ProducerBlockedQuotaExceededException($"{message}. Error code: {error}"),
-                ServerError.ProducerBlockedQuotaExceededException => new ProducerBlockedQuotaExceededException($"{message}. Error code: {error}"),
+                ServerError.ProducerBlockedQuotaExceededError => new ProducerBlockedQuotaExceededException(
+                    $"{message}. Error code: {error}"),
+                ServerError.ProducerBlockedQuotaExceededException => new ProducerBlockedQuotaExceededException(
+                    $"{message}. Error code: {error}"),
                 ServerError.ProducerBusy => new ProducerBusyException(message),
                 ServerError.ServiceNotReady => new ServiceNotReadyException(message),
                 ServerError.SubscriptionNotFound => new SubscriptionNotFoundException(message),
@@ -80,121 +82,57 @@ namespace DotPulsar.Internal.Extensions
             });
 
         public static BaseCommand AsBaseCommand(this CommandAck command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Ack,
-                Ack = command
-            };
+            => new() { CommandType = BaseCommand.Type.Ack, Ack = command };
 
         public static BaseCommand AsBaseCommand(this CommandConnect command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Connect,
-                Connect = command
-            };
+            => new() { CommandType = BaseCommand.Type.Connect, Connect = command };
 
         public static BaseCommand AsBaseCommand(this CommandPing command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Ping,
-                Ping = command
-            };
+            => new() { CommandType = BaseCommand.Type.Ping, Ping = command };
 
         public static BaseCommand AsBaseCommand(this CommandPong command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Pong,
-                Pong = command
-            };
+            => new() { CommandType = BaseCommand.Type.Pong, Pong = command };
 
         public static BaseCommand AsBaseCommand(this CommandProducer command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Producer,
-                Producer = command
-            };
+            => new() { CommandType = BaseCommand.Type.Producer, Producer = command };
 
         public static BaseCommand AsBaseCommand(this CommandGetLastMessageId command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.GetLastMessageId,
-                GetLastMessageId = command
-            };
+            => new() { CommandType = BaseCommand.Type.GetLastMessageId, GetLastMessageId = command };
 
         public static BaseCommand AsBaseCommand(this CommandUnsubscribe command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Unsubscribe,
-                Unsubscribe = command
-            };
+            => new() { CommandType = BaseCommand.Type.Unsubscribe, Unsubscribe = command };
 
         public static BaseCommand AsBaseCommand(this CommandSubscribe command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Subscribe,
-                Subscribe = command
-            };
+            => new() { CommandType = BaseCommand.Type.Subscribe, Subscribe = command };
 
         public static BaseCommand AsBaseCommand(this CommandLookupTopic command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Lookup,
-                LookupTopic = command
-            };
+            => new() { CommandType = BaseCommand.Type.Lookup, LookupTopic = command };
 
         public static BaseCommand AsBaseCommand(this CommandSend command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Send,
-                Send = command
-            };
+            => new() { CommandType = BaseCommand.Type.Send, Send = command };
 
         public static BaseCommand AsBaseCommand(this CommandFlow command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Flow,
-                Flow = command
-            };
+            => new() { CommandType = BaseCommand.Type.Flow, Flow = command };
 
         public static BaseCommand AsBaseCommand(this CommandCloseProducer command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.CloseProducer,
-                CloseProducer = command
-            };
+            => new() { CommandType = BaseCommand.Type.CloseProducer, CloseProducer = command };
 
         public static BaseCommand AsBaseCommand(this CommandCloseConsumer command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.CloseConsumer,
-                CloseConsumer = command
-            };
+            => new() { CommandType = BaseCommand.Type.CloseConsumer, CloseConsumer = command };
 
         public static BaseCommand AsBaseCommand(this CommandSeek command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.Seek,
-                Seek = command
-            };
-        
+            => new() { CommandType = BaseCommand.Type.Seek, Seek = command };
+
         public static BaseCommand AsBaseCommand(this CommandRedeliverUnacknowledgedMessages command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.RedeliverUnacknowledgedMessages,
-                RedeliverUnacknowledgedMessages = command
-            };
+            => new() { CommandType = BaseCommand.Type.RedeliverUnacknowledgedMessages, RedeliverUnacknowledgedMessages = command };
 
         public static BaseCommand AsBaseCommand(this CommandGetOrCreateSchema command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.GetOrCreateSchema,
-                GetOrCreateSchema = command
-            };
+            => new() { CommandType = BaseCommand.Type.GetOrCreateSchema, GetOrCreateSchema = command };
 
         public static BaseCommand AsBaseCommand(this CommandPartitionedTopicMetadata command)
-            => new()
-            {
-                CommandType = BaseCommand.Type.PartitionedMetadata, PartitionMetadata = command
-            };
+            => new() { CommandType = BaseCommand.Type.PartitionedMetadata, PartitionMetadata = command };
+
+        public static BaseCommand AsBaseCommand(this CommandGetTopicsOfNamespace command)
+            => new() { CommandType = BaseCommand.Type.GetTopicsOfNamespace, GetTopicsOfNamespace = command };
     }
 }

--- a/src/DotPulsar/Internal/Extensions/MessageIdDataExtensions.cs
+++ b/src/DotPulsar/Internal/Extensions/MessageIdDataExtensions.cs
@@ -14,19 +14,23 @@
 
 namespace DotPulsar.Internal.Extensions
 {
-    using DotPulsar.Internal.PulsarApi;
+    using DotPulsar.Abstractions;
+    using PulsarApi;
+    using System;
 
     public static class MessageIdDataExtensions
     {
-        public static MessageId ToMessageId(this MessageIdData messageIdData)
-            => new(messageIdData.LedgerId, messageIdData.EntryId, messageIdData.Partition, messageIdData.BatchIndex);
+        public static MessageId ToMessageId(this MessageIdData messageIdData, string topic)
+            => new(messageIdData.LedgerId, messageIdData.EntryId, messageIdData.Partition, messageIdData.BatchIndex, topic);
 
-        public static void MapFrom(this MessageIdData destination, MessageId source)
+        public static void MapFrom(this MessageIdData destination, IMessageId source)
         {
-            destination.LedgerId = source.LedgerId;
-            destination.EntryId = source.EntryId;
-            destination.Partition = source.Partition;
-            destination.BatchIndex = source.BatchIndex;
+            if (source is not MessageId messageId)
+                throw new ArgumentException($"source should be {nameof(MessageId)} instance");
+            destination.LedgerId = messageId.LedgerId;
+            destination.EntryId = messageId.EntryId;
+            destination.Partition = messageId.Partition;
+            destination.BatchIndex = messageId.BatchIndex;
         }
     }
 }

--- a/src/DotPulsar/Internal/Message.cs
+++ b/src/DotPulsar/Internal/Message.cs
@@ -24,6 +24,7 @@ namespace DotPulsar.Internal
         private readonly ISchema<TValue> _schema;
 
         internal Message(
+            string topic,
             MessageId messageId,
             ReadOnlySequence<byte> data,
             string producerName,
@@ -38,6 +39,7 @@ namespace DotPulsar.Internal
             byte[]? schemaVersion,
             ISchema<TValue> schema)
         {
+            Topic = topic;
             MessageId = messageId;
             Data = data;
             ProducerName = producerName;
@@ -93,6 +95,9 @@ namespace DotPulsar.Internal
 
         public IReadOnlyDictionary<string, string> Properties { get; }
 
-        public TValue Value() => _schema.Decode(Data);
+        public TValue Value()
+            => _schema.Decode(Data);
+
+        public string Topic { get; }
     }
 }

--- a/src/DotPulsar/Internal/MessageFactory.cs
+++ b/src/DotPulsar/Internal/MessageFactory.cs
@@ -14,9 +14,9 @@
 
 namespace DotPulsar.Internal
 {
+    using Abstractions;
     using DotPulsar.Abstractions;
-    using DotPulsar.Internal.Abstractions;
-    using DotPulsar.Internal.PulsarApi;
+    using PulsarApi;
     using System.Buffers;
     using System.Collections.Generic;
 
@@ -24,7 +24,8 @@ namespace DotPulsar.Internal
     {
         private static readonly Dictionary<string, string> _empty;
 
-        static MessageFactory() => _empty = new Dictionary<string, string>();
+        static MessageFactory()
+            => _empty = new Dictionary<string, string>();
 
         private static IReadOnlyDictionary<string, string> FromKeyValueList(List<KeyValue> keyValues)
         {
@@ -47,21 +48,25 @@ namespace DotPulsar.Internal
         public MessageFactory(ISchema<TValue> schema)
             => _schema = schema;
 
-        public IMessage<TValue> Create(MessageId messageId, uint redeliveryCount, ReadOnlySequence<byte> data, MessageMetadata metadata, SingleMessageMetadata? singleMetadata = null)
+        public IMessage<TValue> Create(string topic, MessageId messageId, uint redeliveryCount,
+            ReadOnlySequence<byte> data, MessageMetadata metadata, SingleMessageMetadata?
+                singleMetadata = null)
         {
             if (singleMetadata is null)
-                return Create(messageId, redeliveryCount, metadata, data);
+                return Create(topic, messageId, redeliveryCount, metadata, data);
 
-            return Create(messageId, redeliveryCount, metadata, singleMetadata, data);
+            return Create(topic, messageId, redeliveryCount, metadata, singleMetadata, data);
         }
 
         private Message<TValue> Create(
+            string topic,
             MessageId messageId,
             uint redeliveryCount,
             MessageMetadata metadata,
             ReadOnlySequence<byte> data)
         {
             return new Message<TValue>(
+                topic: topic,
                 messageId: messageId,
                 data: data,
                 producerName: metadata.ProducerName,
@@ -78,6 +83,7 @@ namespace DotPulsar.Internal
         }
 
         private Message<TValue> Create(
+            string topic,
             MessageId messageId,
             uint redeliveryCount,
             MessageMetadata metadata,
@@ -85,6 +91,7 @@ namespace DotPulsar.Internal
             ReadOnlySequence<byte> data)
         {
             return new Message<TValue>(
+                topic: topic,
                 messageId: messageId,
                 data: data,
                 producerName: metadata.ProducerName,

--- a/src/DotPulsar/Internal/NamespaceName.cs
+++ b/src/DotPulsar/Internal/NamespaceName.cs
@@ -1,0 +1,119 @@
+namespace DotPulsar.Internal
+{
+    using System;
+    using System.Text.RegularExpressions;
+
+    public class NamespaceName
+    {
+        // allowed characters for property, namespace, cluster and topic names are
+        // alphanumeric (a-zA-Z_0-9) and these special chars -=:.
+        // % is allowed as part of valid URL encoding
+        private static Regex _NAMED_ENTITY_PATTERN = new("^[-=:.\\w]*$");
+        private readonly string _tenant;
+        private readonly string? _cluster;
+        private readonly string _localName;
+        private readonly string _ns;
+        private readonly bool _isV2;
+
+        private NamespaceName(string ns)
+        {
+            if (string.IsNullOrEmpty(ns))
+            {
+                throw new ArgumentException("Invalid null namespace: " + ns);
+            }
+
+            // Verify it's a proper namespace
+            // The namespace name is composed of <tenant>/<namespace>
+            // or in the legacy format with the cluster name:
+            // <tenant>/<cluster>/<namespace>
+            try
+            {
+                string[] parts = ns.Split('/');
+
+                switch (parts.Length)
+                {
+                    case 2:
+                        // New style namespace : <tenant>/<namespace>
+                        ValidateNamespaceName(parts[0], parts[1]);
+
+                        _tenant = parts[0];
+                        _cluster = null;
+                        _localName = parts[1];
+                        _isV2 = true;
+                        break;
+                    case 3:
+                        // Old style namespace: <tenant>/<cluster>/<namespace>
+                        ValidateNamespaceName(parts[0], parts[1], parts[2]);
+
+                        _tenant = parts[0];
+                        _cluster = parts[1];
+                        _localName = parts[2];
+                        _isV2 = false;
+                        break;
+                    default: throw new ArgumentNullException("Invalid namespace format. namespace: " + ns);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new AggregateException("Invalid namespace format."
+                                             + " expected <tenant>/<namespace> or <tenant>/<cluster>/<namespace> "
+                                             + "but got: " + ns, e);
+            }
+
+            this._ns = ns;
+        }
+
+        public static NamespaceName Get(string tenant, string ns)
+        {
+            ValidateNamespaceName(tenant, ns);
+            return new NamespaceName(tenant + '/' + ns);
+        }
+
+        public static NamespaceName Get(string tenant, string cluster, string ns)
+        {
+            ValidateNamespaceName(tenant, cluster, ns);
+            return new NamespaceName(tenant + '/' + cluster + '/' + ns);
+        }
+
+        public bool IsV2Namespace()
+        {
+            return _isV2;
+        }
+
+        public override string ToString()
+        {
+            return _ns;
+        }
+
+        private static void CheckName(string name)
+        {
+            if (!_NAMED_ENTITY_PATTERN.IsMatch(name))
+            {
+                throw new ArgumentException("Invalid named entity: " + name);
+            }
+        }
+
+        private static void ValidateNamespaceName(string tenant, string ns)
+        {
+            if (string.IsNullOrEmpty(tenant) || string.IsNullOrEmpty(ns))
+            {
+                throw new ArgumentException($"Invalid namespace format. namespace: {tenant}/{ns}");
+            }
+
+            CheckName(tenant);
+            CheckName(ns);
+        }
+
+        private static void ValidateNamespaceName(string tenant, string cluster, string ns)
+        {
+            if (string.IsNullOrEmpty(tenant) || string.IsNullOrEmpty(cluster) || string.IsNullOrEmpty(ns))
+            {
+                throw new ArgumentException($"Invalid namespace format. namespace: {tenant}/{cluster}/{ns}");
+            }
+
+            CheckName(tenant);
+            CheckName(cluster);
+            CheckName(ns);
+        }
+    }
+}

--- a/src/DotPulsar/Internal/NotReadyChannel.cs
+++ b/src/DotPulsar/Internal/NotReadyChannel.cs
@@ -31,10 +31,11 @@ namespace DotPulsar.Internal
         public ValueTask ClosedByClient(CancellationToken cancellationToken)
             => new();
 
-        public ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken = default)
+        public ValueTask<IMessage<TMessage>> Receive(string topic, CancellationToken cancellationToken = default)
             => throw GetException();
 
-        public Task<CommandSendReceipt> Send(MessageMetadata metadata, ReadOnlySequence<byte> payload, CancellationToken cancellationToken)
+        public Task<CommandSendReceipt> Send(MessageMetadata metadata, ReadOnlySequence<byte> payload,
+            CancellationToken cancellationToken)
             => throw GetException();
 
         public Task Send(CommandAck command, CancellationToken cancellationToken)
@@ -49,7 +50,7 @@ namespace DotPulsar.Internal
         public Task Send(CommandSeek command, CancellationToken cancellationToken)
             => throw GetException();
 
-        public Task<MessageId> Send(CommandGetLastMessageId command, CancellationToken cancellationToken)
+        public Task<MessageId> Send(string topic, CommandGetLastMessageId command, CancellationToken cancellationToken)
             => throw GetException();
 
         private static Exception GetException()

--- a/src/DotPulsar/Internal/Reader.cs
+++ b/src/DotPulsar/Internal/Reader.cs
@@ -17,8 +17,8 @@ namespace DotPulsar.Internal
     using Abstractions;
     using DotPulsar.Abstractions;
     using DotPulsar.Exceptions;
-    using DotPulsar.Internal.PulsarApi;
     using Events;
+    using PulsarApi;
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -71,16 +71,17 @@ namespace DotPulsar.Internal
         public bool IsFinalState(ReaderState state)
             => _state.IsFinalState(state);
 
-        public async ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken)
+        public async ValueTask<IMessageId> GetLastMessageId(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             var getLastMessageId = new CommandGetLastMessageId();
+
             return await _executor.Execute(() => GetLastMessageId(getLastMessageId, cancellationToken), cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask<MessageId> GetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
-            => await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+            => await _channel.Send(Topic, command, cancellationToken).ConfigureAwait(false);
 
         public async ValueTask<IMessage<TMessage>> Receive(CancellationToken cancellationToken)
         {
@@ -90,7 +91,7 @@ namespace DotPulsar.Internal
         }
 
         private async ValueTask<IMessage<TMessage>> ReceiveMessage(CancellationToken cancellationToken)
-            => await _channel.Receive(cancellationToken).ConfigureAwait(false);
+            => await _channel.Receive(Topic, cancellationToken).ConfigureAwait(false);
 
         public async ValueTask Seek(MessageId messageId, CancellationToken cancellationToken)
         {

--- a/src/DotPulsar/Internal/RegexSubscriptionMode.cs
+++ b/src/DotPulsar/Internal/RegexSubscriptionMode.cs
@@ -1,0 +1,20 @@
+﻿namespace DotPulsar.Internal
+{
+    public enum RegexSubscriptionMode : byte
+    {
+        /// <summary>
+        /// Only subscribe to persistent topics.
+        /// </summary>
+        PersistentOnly,
+
+        /// <summary>
+        /// Only subscribe to non-persistent topics.
+        /// </summary>
+        NonPersistentOnly,
+
+        /// <summary>
+        /// Subscribe to both persistent and non-persistent topics.
+        /// </summary>
+        AllTopics
+    }
+}

--- a/src/DotPulsar/Internal/RequestResponseHandler.cs
+++ b/src/DotPulsar/Internal/RequestResponseHandler.cs
@@ -14,9 +14,9 @@
 
 namespace DotPulsar.Internal
 {
-    using DotPulsar.Internal.Abstractions;
-    using DotPulsar.Internal.Requests;
+    using Abstractions;
     using PulsarApi;
+    using Requests;
     using System;
     using System.Threading.Tasks;
 
@@ -40,6 +40,7 @@ namespace DotPulsar.Internal
             _getResponseIdentifier.Set(BaseCommand.Type.CloseProducer, cmd => StandardRequest.WithProducerId(cmd.CloseProducer.RequestId, cmd.CloseProducer.ProducerId));
             _getResponseIdentifier.Set(BaseCommand.Type.LookupResponse, cmd => StandardRequest.WithRequestId(cmd.LookupTopicResponse.RequestId));
             _getResponseIdentifier.Set(BaseCommand.Type.PartitionedMetadataResponse, cmd => StandardRequest.WithRequestId(cmd.PartitionMetadataResponse.RequestId));
+            _getResponseIdentifier.Set(BaseCommand.Type.GetTopicsOfNamespaceResponse, cmd => StandardRequest.WithRequestId(cmd.GetTopicsOfNamespaceResponse.RequestId));
             _getResponseIdentifier.Set(BaseCommand.Type.GetLastMessageIdResponse, cmd => StandardRequest.WithRequestId(cmd.GetLastMessageIdResponse.RequestId));
             _getResponseIdentifier.Set(BaseCommand.Type.GetOrCreateSchemaResponse, cmd => StandardRequest.WithRequestId(cmd.GetOrCreateSchemaResponse.RequestId));
             _getResponseIdentifier.Set(BaseCommand.Type.Success, cmd => StandardRequest.WithRequestId(cmd.Success.RequestId));
@@ -112,6 +113,12 @@ namespace DotPulsar.Internal
             return _requests.CreateTask(StandardRequest.WithRequestId(command.RequestId));
         }
 
+        public Task<BaseCommand> Outgoing(CommandGetTopicsOfNamespace command)
+        {
+            command.RequestId = _requestId.FetchNext();
+            return _requests.CreateTask(StandardRequest.WithRequestId(command.RequestId));
+        }
+
         public Task<BaseCommand> Outgoing(CommandSeek command)
         {
             command.RequestId = _requestId.FetchNext();
@@ -135,6 +142,7 @@ namespace DotPulsar.Internal
         public void Incoming(CommandCloseConsumer command)
         {
             var requests = _requests.Keys;
+
             foreach (var request in requests)
             {
                 if (request.SenderIsConsumer(command.ConsumerId))
@@ -150,6 +158,7 @@ namespace DotPulsar.Internal
         public void Incoming(CommandCloseProducer command)
         {
             var requests = _requests.Keys;
+
             foreach (var request in requests)
             {
                 if (request.SenderIsProducer(command.ProducerId))

--- a/src/DotPulsar/Internal/SubConsumer.cs
+++ b/src/DotPulsar/Internal/SubConsumer.cs
@@ -17,8 +17,8 @@ namespace DotPulsar.Internal
     using Abstractions;
     using DotPulsar.Abstractions;
     using DotPulsar.Exceptions;
-    using DotPulsar.Internal.Extensions;
     using Events;
+    using Extensions;
     using Microsoft.Extensions.ObjectPool;
     using PulsarApi;
     using System;
@@ -42,6 +42,13 @@ namespace DotPulsar.Internal
         public string SubscriptionName { get; }
         public string Topic { get; }
 
+        public ISet<string>? TopicNames { get; }
+        public string? TopicsPattern { get; }
+        public RegexSubscriptionMode RegexSubscriptionMode { get; }
+        public uint NumberOfPartitions { get; }
+        public bool AutoUpdatePartitions { get; }
+        public TimeSpan AutoUpdatePartitionsInterval { get; }
+
         public SubConsumer(
             Guid correlationId,
             Uri serviceUrl,
@@ -51,7 +58,8 @@ namespace DotPulsar.Internal
             IConsumerChannel<TMessage> initialChannel,
             IExecute executor,
             IStateChanged<ConsumerState> state,
-            IConsumerChannelFactory<TMessage> factory)
+            IConsumerChannelFactory<TMessage> factory
+        )
         {
             _correlationId = correlationId;
             ServiceUrl = serviceUrl;
@@ -71,7 +79,8 @@ namespace DotPulsar.Internal
         public async ValueTask<ConsumerState> OnStateChangeTo(ConsumerState state, CancellationToken cancellationToken)
             => await _state.StateChangedTo(state, cancellationToken).ConfigureAwait(false);
 
-        public async ValueTask<ConsumerState> OnStateChangeFrom(ConsumerState state, CancellationToken cancellationToken)
+        public async ValueTask<ConsumerState> OnStateChangeFrom(ConsumerState state,
+            CancellationToken cancellationToken)
             => await _state.StateChangedFrom(state, cancellationToken).ConfigureAwait(false);
 
         public bool IsFinalState()
@@ -94,40 +103,48 @@ namespace DotPulsar.Internal
         {
             ThrowIfDisposed();
 
-            return await _executor.Execute(() => ReceiveMessage(cancellationToken), cancellationToken).ConfigureAwait(false);
+            return await _executor.Execute(() => ReceiveMessage(Topic, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        private async ValueTask<IMessage<TMessage>> ReceiveMessage(CancellationToken cancellationToken)
-            => await _channel.Receive(cancellationToken).ConfigureAwait(false);
+        private async ValueTask<IMessage<TMessage>> ReceiveMessage(string topic, CancellationToken cancellationToken)
+            => await _channel.Receive(topic, cancellationToken).ConfigureAwait(false);
 
-        public async ValueTask Acknowledge(MessageId messageId, CancellationToken cancellationToken)
+        public async ValueTask Acknowledge(IMessageId messageId, CancellationToken cancellationToken)
             => await Acknowledge(messageId, CommandAck.AckType.Individual, cancellationToken).ConfigureAwait(false);
 
-        public async ValueTask AcknowledgeCumulative(MessageId messageId, CancellationToken cancellationToken)
+        public async ValueTask AcknowledgeCumulative(IMessageId messageId, CancellationToken cancellationToken)
             => await Acknowledge(messageId, CommandAck.AckType.Cumulative, cancellationToken).ConfigureAwait(false);
 
-        public async ValueTask RedeliverUnacknowledgedMessages(IEnumerable<MessageId> messageIds, CancellationToken cancellationToken)
+        public async ValueTask RedeliverUnacknowledgedMessages(IEnumerable<IMessageId> messageIds, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             var command = new CommandRedeliverUnacknowledgedMessages();
+
             command.MessageIds.AddRange(messageIds.Select(messageId => messageId.ToMessageIdData()));
-            await _executor.Execute(() => RedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken).ConfigureAwait(false);
+
+            await _executor
+                .Execute(() => RedeliverUnacknowledgedMessages(command, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
 
         public async ValueTask RedeliverUnacknowledgedMessages(CancellationToken cancellationToken)
-            => await RedeliverUnacknowledgedMessages(Enumerable.Empty<MessageId>(), cancellationToken).ConfigureAwait(false);
+            => await RedeliverUnacknowledgedMessages(Enumerable.Empty<IMessageId>(), cancellationToken)
+                .ConfigureAwait(false);
 
         public async ValueTask Unsubscribe(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             var unsubscribe = new CommandUnsubscribe();
-            await _executor.Execute(() => Unsubscribe(unsubscribe, cancellationToken), cancellationToken).ConfigureAwait(false);
+
+            await _executor.Execute(() => Unsubscribe(unsubscribe, cancellationToken), cancellationToken)
+                .ConfigureAwait(false);
         }
 
         private async ValueTask Unsubscribe(CommandUnsubscribe command, CancellationToken cancellationToken)
-            =>await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+            => await _channel.Send(command, cancellationToken).ConfigureAwait(false);
 
         public async ValueTask Seek(MessageId messageId, CancellationToken cancellationToken)
         {
@@ -145,7 +162,7 @@ namespace DotPulsar.Internal
             await _executor.Execute(() => Seek(seek, cancellationToken), cancellationToken).ConfigureAwait(false);
         }
 
-        public async ValueTask<MessageId> GetLastMessageId(CancellationToken cancellationToken)
+        public async ValueTask<IMessageId> GetLastMessageId(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -153,20 +170,25 @@ namespace DotPulsar.Internal
             return await _executor.Execute(() => GetLastMessageId(getLastMessageId, cancellationToken), cancellationToken).ConfigureAwait(false);
         }
 
-        private async ValueTask<MessageId> GetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
-            => await _channel.Send(command, cancellationToken).ConfigureAwait(false);
+        private async ValueTask<IMessageId> GetLastMessageId(CommandGetLastMessageId command, CancellationToken cancellationToken)
+            => await _channel.Send(Topic, command, cancellationToken).ConfigureAwait(false);
 
         private async Task Seek(CommandSeek command, CancellationToken cancellationToken)
             => await _channel.Send(command, cancellationToken).ConfigureAwait(false);
 
-        private async ValueTask Acknowledge(MessageId messageId, CommandAck.AckType ackType, CancellationToken cancellationToken)
+        private async ValueTask Acknowledge(IMessageId messageId, CommandAck.AckType ackType, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
             var commandAck = _commandAckPool.Get();
             commandAck.Type = ackType;
+
             if (commandAck.MessageIds.Count == 0)
-                commandAck.MessageIds.Add(messageId.ToMessageIdData());
+            {
+                if (messageId is not MessageId result)
+                    throw new ArgumentException($"messageId should be {nameof(MessageId)} instance");
+                commandAck.MessageIds.Add(result.ToMessageIdData());
+            }
             else
                 commandAck.MessageIds[0].MapFrom(messageId);
 

--- a/src/DotPulsar/Internal/SubProducer.cs
+++ b/src/DotPulsar/Internal/SubProducer.cs
@@ -17,8 +17,8 @@ namespace DotPulsar.Internal
     using Abstractions;
     using DotPulsar.Abstractions;
     using DotPulsar.Exceptions;
-    using DotPulsar.Internal.Extensions;
     using Events;
+    using Extensions;
     using Microsoft.Extensions.ObjectPool;
     using System;
     using System.Buffers;
@@ -91,6 +91,7 @@ namespace DotPulsar.Internal
             await _channel.ClosedByClient(CancellationToken.None).ConfigureAwait(false);
             await _channel.DisposeAsync().ConfigureAwait(false);
         }
+
         public async ValueTask<MessageId> Send(TMessage message, CancellationToken cancellationToken)
             => await Send(_schema.Encode(message), cancellationToken).ConfigureAwait(false);
 
@@ -102,6 +103,7 @@ namespace DotPulsar.Internal
             ThrowIfDisposed();
 
             var metadata = _messageMetadataPool.Get();
+
             try
             {
                 metadata.SequenceId = _sequenceId.FetchNext();
@@ -118,6 +120,7 @@ namespace DotPulsar.Internal
             ThrowIfDisposed();
 
             var autoAssignSequenceId = metadata.SequenceId == 0;
+
             if (autoAssignSequenceId)
                 metadata.SequenceId = _sequenceId.FetchNext();
 
@@ -135,7 +138,7 @@ namespace DotPulsar.Internal
         private async ValueTask<MessageId> Send(PulsarApi.MessageMetadata metadata, ReadOnlySequence<byte> data, CancellationToken cancellationToken)
         {
             var response = await _channel.Send(metadata, data, cancellationToken).ConfigureAwait(false);
-            return response.MessageId.ToMessageId();
+            return response.MessageId.ToMessageId(Topic);
         }
 
         public async Task EstablishNewChannel(CancellationToken cancellationToken)

--- a/src/DotPulsar/Internal/TopicName.cs
+++ b/src/DotPulsar/Internal/TopicName.cs
@@ -1,0 +1,198 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar.Internal
+{
+    using System;
+
+    public class TopicName
+    {
+        private const string PublicTenant = "public";
+        private const string DefaultNamespace = "default";
+        private const string PartitionedTopicSuffix = "-partition-";
+        private const string Persistent = "persistent";
+        private const string NonPersistent = "non-persistent";
+
+        private readonly string _domain;
+        private readonly string _tenant;
+        private readonly string? _cluster;
+        private readonly string _namespacePortion;
+        private readonly string _localName;
+        private readonly NamespaceName _namespaceName;
+        private readonly int _partitionIndex;
+        private readonly string _completeTopicName;
+
+        public TopicName(string completeTopicName)
+        {
+            // The topic name can be in two different forms, one is fully qualified topic name,
+            // the other one is short topic name
+            string[] parts;
+
+            if (!completeTopicName.Contains("://"))
+            {
+                // The short topic name can be:
+                // - <topic>
+                // - <property>/<namespace>/<topic>
+                parts = completeTopicName.Split('/');
+
+                completeTopicName = parts.Length switch
+                {
+                    3 => Persistent + "://" + completeTopicName,
+                    1 => Persistent + "://" + PublicTenant + "/" + DefaultNamespace + "/" + parts[0],
+                    _ => throw new ArgumentException("Invalid short topic name '" + completeTopicName +
+                                                     "', it should be in the format of " +
+                                                     "<tenant>/<namespace>/<topic> or <topic>")
+                };
+            }
+
+            // The fully qualified topic name can be in two different forms:
+            // new:    persistent://tenant/namespace/topic
+            // legacy: persistent://tenant/cluster/namespace/topic
+
+            parts = completeTopicName.Split(new[] { ':', '/', '/' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            _domain = Persistent.Equals(parts[0]) ? Persistent : NonPersistent;
+
+            string rest = parts[1];
+
+            // The rest of the name can be in different forms:
+            // new:    tenant/namespace/<localName>
+            // legacy: tenant/cluster/namespace/<localName>
+            // Examples of localName:
+            // 1. some, name, xyz
+            // 2. xyz-123, feeder-2
+
+            parts = rest.Split(new[] { ':', '/', '/' }, 4, StringSplitOptions.RemoveEmptyEntries);
+
+            switch (parts.Length)
+            {
+                case 3:
+                    // New topic name without cluster name
+                    _tenant = parts[0];
+                    _cluster = null;
+                    _namespacePortion = parts[1];
+                    _localName = parts[2];
+                    _partitionIndex = GetPartitionIndex(completeTopicName);
+                    _namespaceName = NamespaceName.Get(_tenant, _namespacePortion);
+                    break;
+                case 4:
+                    // Legacy topic name that includes cluster name
+                    _tenant = parts[0];
+                    _cluster = parts[1];
+                    _namespacePortion = parts[2];
+                    _localName = parts[3];
+                    _partitionIndex = GetPartitionIndex(completeTopicName);
+                    _namespaceName = NamespaceName.Get(_tenant, _cluster, _namespacePortion);
+                    break;
+                default: throw new ArgumentException("Invalid topic name: " + completeTopicName);
+            }
+
+            if (string.IsNullOrEmpty(_localName))
+            {
+                throw new ArgumentException("Invalid topic name: " + completeTopicName);
+            }
+
+            _completeTopicName =
+                IsV2()
+                    ? $"{_domain}://{_tenant}/{_namespacePortion}/{_localName}"
+                    : $"{_domain}://{_tenant}/{_cluster}/{_namespacePortion}/{_localName}";
+        }
+
+        private bool IsV2()
+        {
+            return _cluster == null;
+        }
+
+        public string GetDomain()
+        {
+            return _domain;
+        }
+
+        public string GetTenant()
+        {
+            return _tenant;
+        }
+
+        public string GetNamespacePortion()
+        {
+            return _namespacePortion;
+        }
+
+        public int GetPartitionIndex()
+        {
+            return _partitionIndex;
+        }
+
+        public string GetLocalName()
+        {
+            return _localName;
+        }
+
+        public NamespaceName GetNamespaceName()
+        {
+            return _namespaceName;
+        }
+
+        private static string SubstringAfterLast(string str, string separator)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+
+            if (string.IsNullOrEmpty(separator))
+            {
+                return "";
+            }
+
+            var pos = str.LastIndexOf(separator, StringComparison.Ordinal);
+            return pos != -1 && pos != str.Length - separator.Length ? str.Substring(pos + separator.Length) : "";
+        }
+
+        private static int GetPartitionIndex(string topic)
+        {
+            var partitionIndex = -1;
+
+            if (!topic.Contains(PartitionedTopicSuffix))
+                return partitionIndex;
+
+            try
+            {
+                var idx = SubstringAfterLast(topic, PartitionedTopicSuffix);
+                partitionIndex = int.Parse(idx);
+
+                if (partitionIndex < 0)
+                {
+                    // for the "topic-partition--1"
+                    partitionIndex = -1;
+                }
+                else if (idx.Length != partitionIndex.ToString().Length)
+                {
+                    // for the "topic-partition-01"
+                    partitionIndex = -1;
+                }
+            }
+            catch (Exception)
+            {
+                // ignore exception
+            }
+
+            return partitionIndex;
+        }
+
+        public override string ToString()
+        {
+            return _completeTopicName;
+        }
+    }
+}

--- a/src/DotPulsar/Internal/TopicsUnderNamespaceMode.cs
+++ b/src/DotPulsar/Internal/TopicsUnderNamespaceMode.cs
@@ -14,13 +14,10 @@
 
 namespace DotPulsar.Internal.Abstractions
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    public interface IConnectionPool : IAsyncDisposable
+    public enum GetTopicsUnderNamespaceMode
     {
-        ValueTask<IConnection> FindConnectionForTopic(string topic, CancellationToken cancellationToken = default);
-        ValueTask<IConnection> GetConnection(Uri serviceUrl, CancellationToken cancellationToken = default);
+        PERSISTENT,
+        NON_PERSISTENT,
+        ALL
     }
 }

--- a/src/DotPulsar/MessageId.cs
+++ b/src/DotPulsar/MessageId.cs
@@ -14,19 +14,20 @@
 
 namespace DotPulsar
 {
-    using DotPulsar.Internal.Extensions;
+    using Abstractions;
+    using Internal.Extensions;
     using Internal.PulsarApi;
     using System;
 
     /// <summary>
     /// Unique identifier of a single message.
     /// </summary>
-    public sealed class MessageId : IEquatable<MessageId>, IComparable<MessageId>
+    public sealed class MessageId : IMessageId, IEquatable<MessageId>
     {
         static MessageId()
         {
-            Earliest = new MessageId(ulong.MaxValue, ulong.MaxValue, -1, -1);
-            Latest = new MessageId(long.MaxValue, long.MaxValue, -1, -1);
+            Earliest = new MessageId(ulong.MaxValue, ulong.MaxValue, -1, -1, "");
+            Latest = new MessageId(long.MaxValue, long.MaxValue, -1, -1, "");
         }
 
         /// <summary>
@@ -42,12 +43,13 @@ namespace DotPulsar
         /// <summary>
         /// Initializes a new instance using the specified ledgerId, entryId, partition and batchIndex.
         /// </summary>
-        public MessageId(ulong ledgerId, ulong entryId, int partition, int batchIndex)
+        public MessageId(ulong ledgerId, ulong entryId, int partition, int batchIndex, string topic)
         {
             LedgerId = ledgerId;
             EntryId = entryId;
             Partition = partition;
             BatchIndex = batchIndex;
+            Topic = topic;
         }
 
         /// <summary>
@@ -70,20 +72,35 @@ namespace DotPulsar
         /// </summary>
         public int BatchIndex { get; }
 
-        public int CompareTo(MessageId? other)
+        /// <summary>
+        /// The id of the topic.
+        /// </summary>
+        public string Topic { get; }
+
+        public int CompareTo(object? i)
         {
-            if (other is null)
+            if (i is null)
                 return 1;
 
-            var result = LedgerId.CompareTo(other.LedgerId);
+            if (i.GetType() != GetType())
+            {
+                throw new Exception("expected MessageId object. Got instance of " + i.GetType());
+            }
+
+            var other = i as MessageId;
+
+            var result = LedgerId.CompareTo(other!.LedgerId);
+
             if (result != 0)
                 return result;
 
             result = EntryId.CompareTo(other.EntryId);
+
             if (result != 0)
                 return result;
 
             result = Partition.CompareTo(other.Partition);
+
             if (result != 0)
                 return result;
 
@@ -106,7 +123,8 @@ namespace DotPulsar
             => o is MessageId id && Equals(id);
 
         public bool Equals(MessageId? other)
-            => other is not null && LedgerId == other.LedgerId && EntryId == other.EntryId && Partition == other.Partition && BatchIndex == other.BatchIndex;
+            => other is not null && LedgerId == other.LedgerId && EntryId == other.EntryId &&
+               Partition == other.Partition && BatchIndex == other.BatchIndex;
 
         public static bool operator ==(MessageId x, MessageId y)
             => ReferenceEquals(x, y) || (x is not null && x.Equals(y));
@@ -120,7 +138,7 @@ namespace DotPulsar
         public override string ToString()
             => $"{LedgerId}:{EntryId}:{Partition}:{BatchIndex}";
 
-        internal MessageIdData ToMessageIdData()
+        public MessageIdData ToMessageIdData()
         {
             var messageIdData = new MessageIdData();
             messageIdData.MapFrom(this);

--- a/src/DotPulsar/MultiMessageId.cs
+++ b/src/DotPulsar/MultiMessageId.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace DotPulsar
+{
+    using Abstractions;
+    using Internal.PulsarApi;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A MessageId implementation that contains a map of topic and MessageId.
+    /// </summary>
+    public class MultiMessageId : IMessageId
+    {
+        public string Topic
+        {
+            get { throw new NotSupportedException($"${GetType().Name} doesn't support this field"); }
+        }
+
+        public MessageIdData ToMessageIdData()
+            => throw new NotSupportedException($"${GetType().Name} doesn't support this method");
+
+        public Dictionary<string, IMessageId> Map { get; }
+
+        public MultiMessageId(Dictionary<string, IMessageId> map)
+        {
+            Map = map ?? throw new ArgumentException("map cannot be null");
+        }
+
+        public int CompareTo(object? o)
+        {
+            if (o is null)
+            {
+                return 1;
+            }
+
+            if (o.GetType() != GetType())
+            {
+                throw new Exception("expected MultiMessageId object. Got instance of " + o.GetType());
+            }
+
+            var otherMap = (o as MultiMessageId)?.Map!;
+
+            if ((Map.Count == 0) && (otherMap.Count == 0))
+            {
+                return 0;
+            }
+
+            if (otherMap.Count != Map.Count)
+            {
+                throw new ArgumentException("Current size and other size not equals");
+            }
+
+            var result = 0;
+
+            foreach (var pair in Map)
+            {
+                var otherMessage = otherMap[pair.Key];
+
+                if (otherMessage == null)
+                {
+                    throw new ArgumentException("Other MessageId not have topic " + pair.Key);
+                }
+
+                var currentResult = pair.Value.CompareTo(otherMessage);
+
+                if (result == 0)
+                {
+                    result = currentResult;
+                }
+                else if (currentResult == 0)
+                {
+                    continue;
+                }
+                else if (result != currentResult)
+                {
+                    throw new ArgumentException(
+                        "Different MessageId in Map get different compare result");
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
+            return result;
+        }
+
+        public bool Equals(MultiMessageId obj)
+        {
+            try
+            {
+                return CompareTo(obj) == 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/DotPulsar/PulsarClient.cs
+++ b/src/DotPulsar/PulsarClient.cs
@@ -15,11 +15,11 @@
 namespace DotPulsar
 {
     using Abstractions;
-    using DotPulsar.Internal.Compression;
-    using DotPulsar.Internal.PulsarApi;
     using Exceptions;
     using Internal;
     using Internal.Abstractions;
+    using Internal.Compression;
+    using Internal.PulsarApi;
     using System;
     using System.Linq;
     using System.Threading;
@@ -65,9 +65,11 @@ namespace DotPulsar
             ThrowIfDisposed();
 
             ICompressorFactory? compressorFactory = null;
+
             if (options.CompressionType != CompressionType.None)
             {
                 var compressionType = (Internal.PulsarApi.CompressionType) options.CompressionType;
+
                 compressorFactory = CompressionFactories.CompressorFactories().SingleOrDefault(f => f.CompressionType == compressionType);
 
                 if (compressorFactory is null)
@@ -106,6 +108,7 @@ namespace DotPulsar
 
             var correlationId = Guid.NewGuid();
             var subscription = $"Reader-{correlationId:N}";
+
             var subscribe = new CommandSubscribe
             {
                 ConsumerName = options.ReaderName ?? subscription,
@@ -117,13 +120,16 @@ namespace DotPulsar
             };
             var messagePrefetchCount = options.MessagePrefetchCount;
             var messageFactory = new MessageFactory<TMessage>(options.Schema);
-            var batchHandler = new BatchHandler<TMessage>(false, messageFactory);
+            var batchHandler = new BatchHandler<TMessage>(options.Topic, false, messageFactory);
             var decompressorFactories = CompressionFactories.DecompressorFactories();
-            var factory = new ConsumerChannelFactory<TMessage>(correlationId, _processManager, _connectionPool, subscribe, messagePrefetchCount, batchHandler, messageFactory, decompressorFactories);
+
+            var factory = new ConsumerChannelFactory<TMessage>(correlationId, _processManager, _connectionPool, subscribe, messagePrefetchCount, batchHandler, messageFactory,
+                decompressorFactories);
             var stateManager = new StateManager<ReaderState>(ReaderState.Disconnected, ReaderState.Closed, ReaderState.ReachedEndOfTopic, ReaderState.Faulted);
             var initialChannel = new NotReadyChannel<TMessage>();
             var executor = new Executor(correlationId, _processManager, _exceptionHandler);
             var reader = new Reader<TMessage>(correlationId, ServiceUrl, options.Topic, _processManager, initialChannel, executor, stateManager, factory);
+
             if (options.StateChangedHandler is not null)
                 _ = StateMonitor.MonitorReader(reader, options.StateChangedHandler);
             var process = new ReaderProcess(correlationId, stateManager, reader);

--- a/tests/DotPulsar.IntegrationTests/ConsumerTests.cs
+++ b/tests/DotPulsar.IntegrationTests/ConsumerTests.cs
@@ -15,11 +15,14 @@
 namespace DotPulsar.IntegrationTests
 {
     using Abstraction;
+    using Abstractions;
     using Extensions;
     using Fixtures;
     using FluentAssertions;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading.Tasks;
     using Xunit;
     using Xunit.Abstractions;
@@ -54,16 +57,20 @@ namespace DotPulsar.IntegrationTests
                 .SubscriptionName("test-sub")
                 .Topic(topicName)
                 .Create();
+            await consumer.StateChangedTo(ConsumerState.Active);
 
             await using var producer = client.NewProducer(Schema.String)
                 .Topic(topicName)
                 .Create();
             await producer.StateChangedTo(ProducerState.Connected);
 
+            var sentMessages = new List<string>();
+
             for (var i = 0; i < msgCount; ++i)
             {
                 var msg = $"{content}-{i}";
                 await producer.Send(msg);
+                sentMessages.Add(msg);
                 _testOutputHelper.WriteLine($"Sent a message to consumer: {msg}");
             }
 
@@ -71,7 +78,7 @@ namespace DotPulsar.IntegrationTests
             for (var i = 0; i < msgCount; ++i)
             {
                 var msg = await consumer.Receive();
-                msg.Value().Should().Be($"{content}-{i}");
+                Assert.Contains(msg.Value(), sentMessages);
                 _testOutputHelper.WriteLine($"Received a message: {msg.Value()}");
                 await consumer.Acknowledge(msg.MessageId);
             }
@@ -83,7 +90,6 @@ namespace DotPulsar.IntegrationTests
             //Arrange
             await using var client = PulsarClient.Builder().ServiceUrl(_pulsarService.GetBrokerUri()).Build();
             string topicName = $"partitioned-consumer-seek-{Guid.NewGuid():N}";
-            const string content = "test-message";
             const int partitions = 3;
             const int msgCount = 10;
 
@@ -94,6 +100,7 @@ namespace DotPulsar.IntegrationTests
                 .SubscriptionName("test-sub")
                 .Topic(topicName)
                 .Create();
+            await consumer.StateChangedTo(ConsumerState.Active);
 
             await using var producer = client.NewProducer(Schema.Int32)
                 .Topic(topicName)
@@ -119,6 +126,7 @@ namespace DotPulsar.IntegrationTests
 
             // The sequential of the partitions for which message is obtained is not guaranteed here
             var message = await consumer.Receive();
+            _testOutputHelper.WriteLine($"Received message: {message.Value()}");
             message.Value().Should().BeLessThan(partitions);
             await consumer.Acknowledge(message.MessageId);
         }
@@ -129,7 +137,6 @@ namespace DotPulsar.IntegrationTests
             //Arrange
             await using var client = PulsarClient.Builder().ServiceUrl(_pulsarService.GetBrokerUri()).Build();
             string topicName = $"partitioned-consumer-redeliver-{Guid.NewGuid():N}";
-            const string content = "test-message";
             const int partitions = 3;
             const int msgCount = 10;
 
@@ -140,6 +147,7 @@ namespace DotPulsar.IntegrationTests
                 .SubscriptionName("test-sub")
                 .Topic(topicName)
                 .Create();
+            await consumer.StateChangedTo(ConsumerState.Active);
 
             await using var producer = client.NewProducer(Schema.Int32)
                 .Topic(topicName)
@@ -167,6 +175,7 @@ namespace DotPulsar.IntegrationTests
 
             // The sequential of the partitions for which message is obtained is not guaranteed here
             var message = await consumer.Receive();
+            _testOutputHelper.WriteLine($"Received message: {message.Value()}");
             message.Value().Should().BeLessThan(partitions * 2);
             message.Value().Should().BeGreaterOrEqualTo(partitions);
             await consumer.Acknowledge(message.MessageId);
@@ -203,6 +212,95 @@ namespace DotPulsar.IntegrationTests
                     throw new TimeoutException(timeoutErrMsg);
             };
             act.Should().NotThrow<TimeoutException>(timeoutErrMsg);
+        }
+
+        [Fact]
+        public async void MultipleTopicsConsumer_WhenSendMessages_ThenGetMessages()
+        {
+            //Arrange
+            await using var client = PulsarClient.Builder().ServiceUrl(_pulsarService.GetBrokerUri()).Build();
+
+            var topics = new List<string> { $"simple-topic-{Guid.NewGuid():N}", $"simple-topic-{Guid.NewGuid():N}", $"simple-topic-{Guid.NewGuid():N}" };
+
+            //Act
+            await using var consumer =
+                client.NewConsumer(Schema.String).Topics(topics).SubscriptionName("test-sub").Create();
+            await consumer.StateChangedTo(ConsumerState.Active);
+
+            var producers = new List<IProducer<string>>();
+
+            foreach (var topic in topics)
+            {
+                var producer = client.NewProducer(Schema.String).Topic(topic).Create();
+                await producer.StateChangedTo(ProducerState.Connected);
+                producers.Add(producer);
+            }
+
+            var sentMessages = new List<string>();
+
+            for (var i = 0; i < producers.Count; i++)
+            {
+                var msg = $"test-message-{i}";
+                await producers[i].Send(msg);
+                _testOutputHelper.WriteLine($"Sent a message to consumer: {msg}");
+                sentMessages.Add(msg);
+            }
+
+            // Assert
+            foreach (var _ in sentMessages)
+            {
+                var receive = await consumer.Receive();
+                _testOutputHelper.WriteLine($"Received message: {receive.Value()}");
+                Assert.Contains(receive.Value(), sentMessages);
+            }
+        }
+
+        private readonly Random _random = new();
+
+        private string RandomString(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+            return new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[_random.Next(s.Length)]).ToArray());
+        }
+
+        [Fact]
+        public async void TopicsPatternConsumer_WhenSendMessages_ThenGetMessages()
+        {
+            await using var client = PulsarClient.Builder().ServiceUrl(_pulsarService.GetBrokerUri()).Build();
+            var prefix = $"{RandomString(5)}-topic-";
+            var topics = Enumerable.Range(0, 3).Select(_ => $"{prefix}{Guid.NewGuid():N}").ToList();
+
+            var producers = new List<IProducer<string>>();
+
+            foreach (var topic in topics)
+            {
+                var producer = client.NewProducer(Schema.String).Topic(topic).Create();
+                await producer.StateChangedTo(ProducerState.Connected);
+                producers.Add(producer);
+            }
+
+            await using var consumer = client.NewConsumer(Schema.String)
+                .TopicsPattern($"persistent://public/default/{prefix}-*").SubscriptionName("test-sub").Create();
+            await consumer.StateChangedTo(ConsumerState.Active);
+
+            var sentMessages = new List<string>();
+
+            for (var i = 0; i < producers.Count; i++)
+            {
+                var msg = $"test-message-{i}";
+                await producers[i].Send(msg);
+                _testOutputHelper.WriteLine($"Sent a message to consumer: {msg}");
+                sentMessages.Add(msg);
+            }
+
+            for (var i = 0; i < producers.Count; i++)
+            {
+                var receive = await consumer.Receive();
+                _testOutputHelper.WriteLine($"Received message: {receive.Value()}");
+                Assert.Contains(receive.Value(), sentMessages);
+            }
         }
     }
 }

--- a/tests/DotPulsar.IntegrationTests/DotPulsar.IntegrationTests.csproj
+++ b/tests/DotPulsar.IntegrationTests/DotPulsar.IntegrationTests.csproj
@@ -7,27 +7,32 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+      <PackageReference Include="Ductus.FluentDocker" Version="2.10.7"/>
+      <PackageReference Include="FluentAssertions" Version="5.10.3"/>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0"/>
+      <PackageReference Include="xunit" Version="2.4.1"/>
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+      <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\DotPulsar\DotPulsar.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotPulsar\DotPulsar.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="docker-compose-standalone-tests.yml">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="docker-compose-standalone-tests.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestResults"/>
+  </ItemGroup>
 
 </Project>

--- a/tests/DotPulsar.StressTests/DotPulsar.StressTests.csproj
+++ b/tests/DotPulsar.StressTests/DotPulsar.StressTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Ductus.FluentDocker" Version="2.10.7"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/DotPulsar.Tests/MessageIdTests.cs
+++ b/tests/DotPulsar.Tests/MessageIdTests.cs
@@ -16,7 +16,6 @@
 
 namespace DotPulsar.Tests
 {
-    using DotPulsar;
     using FluentAssertions;
     using Xunit;
 
@@ -25,8 +24,8 @@ namespace DotPulsar.Tests
         [Fact]
         public void CompareTo_GivenTheSameValues_ShouldBeEqual()
         {
-            var m1 = new MessageId(1, 2, 3, 4);
-            var m2 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(1, 2, 3, 4, "");
+            var m2 = new MessageId(1, 2, 3, 4, "");
 
             m1.CompareTo(m2).Should().Be(0);
             (m1 < m2).Should().BeFalse();
@@ -50,7 +49,7 @@ namespace DotPulsar.Tests
         [Fact]
         public void CompareTo_GivenOneNull_ShouldFollowNull()
         {
-            var m1 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(1, 2, 3, 4, "");
             MessageId m2 = null;
 
             m1.CompareTo(m2).Should().BePositive();
@@ -70,10 +69,11 @@ namespace DotPulsar.Tests
         [InlineData(1, 3, 3, 4)] // EntryId is greater
         [InlineData(1, 2, 4, 4)] // Partition is greater
         [InlineData(1, 2, 3, 5)] // BatchIndex is greater
-        public void CompareTo_GivenCurrentFollowsArgument_ShouldReturnPositive(ulong ledgerId, ulong entryId, int partition, int batchIndex)
+        public void CompareTo_GivenCurrentFollowsArgument_ShouldReturnPositive(ulong ledgerId, ulong entryId,
+            int partition, int batchIndex)
         {
-            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex);
-            var m2 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex, "");
+            var m2 = new MessageId(1, 2, 3, 4, "");
 
             m1.CompareTo(m2).Should().BePositive();
             (m1 > m2).Should().BeTrue();
@@ -85,10 +85,11 @@ namespace DotPulsar.Tests
         [InlineData(1, 1, 3, 4)] // EntryId is less
         [InlineData(1, 2, 2, 4)] // Partition is less
         [InlineData(1, 2, 3, 3)] // BatchIndex is less
-        public void CompareTo_GivenCurrentPrecedesArgument_ShouldReturnNegative(ulong ledgerId, ulong entryId, int partition, int batchIndex)
+        public void CompareTo_GivenCurrentPrecedesArgument_ShouldReturnNegative(ulong ledgerId, ulong entryId,
+            int partition, int batchIndex)
         {
-            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex);
-            var m2 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex, "");
+            var m2 = new MessageId(1, 2, 3, 4, "");
 
             m1.CompareTo(m2).Should().BeNegative();
             (m1 < m2).Should().BeTrue();
@@ -98,7 +99,7 @@ namespace DotPulsar.Tests
         [Fact]
         public void Equals_GivenTheSameObject_ShouldBeEqual()
         {
-            var m1 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(1, 2, 3, 4, "");
             var m2 = m1;
 
             m1.Equals(m2).Should().BeTrue();
@@ -109,8 +110,8 @@ namespace DotPulsar.Tests
         [Fact]
         public void Equals_GivenTheSameValues_ShouldBeEqual()
         {
-            var m1 = new MessageId(1, 2, 3, 4);
-            var m2 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(1, 2, 3, 4, "");
+            var m2 = new MessageId(1, 2, 3, 4, "");
 
             m1.Equals(m2).Should().BeTrue();
             (m1 == m2).Should().BeTrue();
@@ -122,11 +123,11 @@ namespace DotPulsar.Tests
         [InlineData(1, 0, 3, 4)] // EntryId not the same
         [InlineData(1, 2, 0, 4)] // Partition not the same
         [InlineData(1, 2, 3, 0)] // BatchIndex not the same
-        public void Equals_GivenDifferentValues_ShouldNotBeEqual(ulong ledgerId, ulong entryId, int partition, int batchIndex)
+        public void Equals_GivenDifferentValues_ShouldNotBeEqual(ulong ledgerId, ulong entryId, int partition,
+            int batchIndex)
         {
-            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex);
-            var m2 = new MessageId(1, 2, 3, 4);
-
+            var m1 = new MessageId(ledgerId, entryId, partition, batchIndex, "");
+            var m2 = new MessageId(1, 2, 3, 4, "");
             m1.Equals(m2).Should().BeFalse();
             (m1 == m2).Should().BeFalse();
             (m1 != m2).Should().BeTrue();
@@ -146,7 +147,7 @@ namespace DotPulsar.Tests
         [Fact]
         public void Equals_GivenOneNull_ShouldNotBeEqual()
         {
-            var m1 = new MessageId(1, 2, 3, 4);
+            var m1 = new MessageId(1, 2, 3, 4, "");
             MessageId m2 = null;
 
             (m1 is null).Should().BeFalse();


### PR DESCRIPTION
Issue: https://github.com/streamnative/support-tickets/issues/205

### Features

- Add `TopicNames` - Multiple topics are supprted
- Add `TopicsPattern` - Support the use of matching pattern to consume multiple topics
- Add `RegexSubscriptionMode` - The subscription mode for TopicsPattern
- Add `NumberOfPartitions` - The consumer's topic partition number
- Add `AutoUpdatePartitions` - Controls whether the consumers automatically update partition data
- Add `AutoUpdatePartitionsInterval` - Set the interval of updating partitions, the default is 1 minute
- Support get topic name from `IMessage` and `IMessageId`
